### PR TITLE
Changed dlmod option example. NAME was missing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is to make sure net-snmp is installed and configured correctly. For more in
 IMPORTANT!
 For this module to work as it is supposed to, you need to specify the libcmaX64.so in the dlmod-variable for the snmp-module.
 This is done by adding the following in your hiera:
-snmp::dlmod: [ '/usr/lib64/libcmaX64.so' ]
+snmp::dlmod: [ 'cmaX /usr/lib64/libcmaX64.so' ]
 
 To solve this a smoother way is on the "todo"-list of the next version.
 


### PR DESCRIPTION
From puppet-snmp README:
Array of dlmod lines to add to the snmpd.conf file. Must provide
NAME and PATH (ex. "cmaX /usr/lib64/libcmaX64.so").